### PR TITLE
checksum: use filename as secondary key for sorting

### DIFF
--- a/lib/bb/checksum.py
+++ b/lib/bb/checksum.py
@@ -140,5 +140,5 @@ class FileChecksumCache(MultiProcessCache):
                 if checksum:
                     checksums.append((pth, checksum))
 
-        checksums.sort(key=operator.itemgetter(1))
+        checksums.sort(key=operator.itemgetter(1, 0))
         return checksums


### PR DESCRIPTION
The output of get_checksums() was not deterministic if copies of files existed within the source tree, because the list of files/checksums was only being sorted by the checksum field.

So add the filename as a secondary key to sort with so that the list ordering is deterministic and won't cause hashes to change