### PR TITLE
fetch2/s3: use more efficient boto3 when available

### DIFF
--- a/lib/bb/fetch2/s3.py
+++ b/lib/bb/fetch2/s3.py
@@ -19,9 +19,17 @@ import os
 import bb
 import urllib.request, urllib.parse, urllib.error
 import re
+import time
 from bb.fetch2 import FetchMethod
 from bb.fetch2 import FetchError
 from bb.fetch2 import runfetchcmd
+
+try:
+    import boto3
+    import botocore.exceptions
+except Exception:
+    # We will test for their existence later
+    pass
 
 def convertToBytes(value, unit):
     value = float(value)
@@ -32,6 +40,14 @@ def convertToBytes(value, unit):
     elif (unit == "GiB"):
         value = value*1024.0*1024.0*1024.0;
     return value
+
+def convertBytesToStr(value):
+    for unit in ["B", "KiB", "MiB", "GiB", "TiB"]:
+        if value < 1024:
+            return f"{value:.2f} {unit}"
+        value /= 1024
+
+    return f"{value:.2f} PiB"
 
 class S3ProgressHandler(bb.progress.LineFilterProgressHandler):
     """
@@ -59,8 +75,51 @@ class S3ProgressHandler(bb.progress.LineFilterProgressHandler):
         return True
 
 
+class BotoProgress():
+    def __init__(self, d, size):
+        self._data = d
+        self._size = size
+        self._last_time = time.time()
+        self._last_size = 0
+        self._last_rate = None
+
+    def progress_update(self, downloaded):
+        new_size = self._last_size + downloaded
+        progress = 100 * new_size / self._size
+        if progress > 100:
+            progress = 100
+
+        if self._size:
+            diff_size = new_size - self._last_size
+            new_time = time.time()
+            diff_time = new_time - self._last_time
+            rate = diff_size / diff_time
+            if self._last_rate:
+                # Do some very simple rate smoothing by averaging in the last
+                # rate to the current one.
+                rate = (self._last_rate + rate) / 2
+            rate_str = f"{convertBytesToStr(rate)}/s"
+
+            self._last_rate = rate
+            self._last_time = new_time
+            self._last_size = new_size
+        else:
+            rate = None
+
+        bb.event.fire(bb.build.TaskProgress(progress, rate_str), self._data)
+
+
 class S3(FetchMethod):
     """Class to fetch urls via 'aws s3'"""
+
+    def __init__(self):
+        try:
+            # If this fails it means boto3 wasn't available or some other issue
+            # exists with boto3 so we will simply fallback to the less
+            # efficient awscli method.
+            self._s3 = boto3.client('s3')
+        except Exception:
+            self._s3 = None
 
     def supports(self, ud, d):
         """
@@ -81,6 +140,24 @@ class S3(FetchMethod):
 
         ud.basecmd = d.getVar("FETCHCMD_s3") or "/usr/bin/env aws s3"
 
+    def _boto_download(self, ud, d):
+        key = ud.path.lstrip("/")
+        try:
+            size = self._s3.head_object(Bucket=ud.host, Key=key)["ResponseMetadata"]["HTTPHeaders"]["content-length"]
+            size = int(size)
+        except Exception:
+            size = None
+        progress = BotoProgress(d, size)
+        try:
+            self._s3.download_file(ud.host, key, ud.localpath, Callback=progress.progress_update)
+        except botocore.exceptions.ClientError as e:
+            if e.response['Error']['Code'] == "404":
+                raise FetchError(f"boto3 failed to find {ud.url}")
+            elif e.response['Error']['Code'] == 403:
+                raise FetchError(f"boto3 does not have access to {ud.url}")
+            raise FetchError(f"boto3 failed to download {ud.url}. Error code: {e.response['Error']['Code']}")
+        return True
+
     def download(self, ud, d):
         """
         Fetch urls
@@ -89,6 +166,9 @@ class S3(FetchMethod):
 
         cmd = '%s cp s3://%s%s %s' % (ud.basecmd, ud.host, ud.path, ud.localpath)
         bb.fetch2.check_network_access(d, cmd, ud.url)
+
+        if self._s3:
+            return self._boto_download(ud, d)
 
         progresshandler = S3ProgressHandler(d)
         runfetchcmd(cmd, d, False, log=progresshandler)
@@ -106,6 +186,18 @@ class S3(FetchMethod):
 
         return True
 
+    def _boto_checkstatus(self, ud):
+        key = ud.path.lstrip("/")
+        try:
+            self._s3.head_object(Bucket=ud.host, Key=key)
+        except botocore.exceptions.ClientError as e:
+            if e.response['Error']['Code'] == "404":
+                raise FetchError(f"boto3 failed to find {ud.url}")
+            elif e.response['Error']['Code'] == 403:
+                raise FetchError(f"boto3 does not have access to {ud.url}")
+            raise FetchError(f"boto3 failed to access {ud.url}. Error code: {e.response['Error']['Code']}")
+        return True
+
     def checkstatus(self, fetch, ud, d):
         """
         Check the status of a URL
@@ -113,6 +205,10 @@ class S3(FetchMethod):
 
         cmd = '%s ls s3://%s%s' % (ud.basecmd, ud.host, ud.path)
         bb.fetch2.check_network_access(d, cmd, ud.url)
+
+        if self._s3:
+            return self._boto_checkstatus(ud)
+
         output = runfetchcmd(cmd, d)
 
         # "aws s3 ls s3://mybucket/foo" will exit with success even if the file


### PR DESCRIPTION
When boto3 is available it is significantly faster than the awscli method. Mainly because it doesn't require that we fork and exec for each individual interaction with s3.

In the case that boto3 is not available this will simply fall back to the less efficient awscli.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BadgerTechnologies/bitbake/2)
<!-- Reviewable:end -->
